### PR TITLE
Fix: unit of read() and open() do not the same

### DIFF
--- a/Example - Single crystal with material vox file/initializations.f
+++ b/Example - Single crystal with material vox file/initializations.f
@@ -104,7 +104,7 @@
           do iele=1,numel
 !
               dummy=0.
-              read(100,*) dummy(1:8)
+              read(200,*) dummy(1:8)
 !
 !             Bunge angles in degrees
               Euler(iele,1) = dummy(1)


### PR DESCRIPTION
In my opinion, the read() function should get data from open() function to assign to dummy(:) variable, so the unit of read() and open() should be the same.